### PR TITLE
feat: write_fileツール追加とapply_patch引数契約の整合

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,6 +7,7 @@ import {
 import { applyPatch } from "./tools/edit/apply_patch/tool";
 import { readFile } from "./tools/edit/read_file/tool";
 import { tree } from "./tools/edit/tree/tool";
+import { writeFile } from "./tools/edit/write_file/tool";
 import { execCommand } from "./tools/exec/exec_command/tool";
 import { gitStatusSummary } from "./tools/git/git_status_summary/tool";
 import { SecurityBypass } from "./security/bypass";
@@ -58,6 +59,15 @@ export const ToolCatalog = {
     },
     handler: execCommand,
   },
+  write_file: {
+    metadata: {
+      name: "write_file",
+      isWriteOp: true,
+      description:
+        "Writes UTF-8 text to a file in the workspace. Use this for full content writes or creating new files.",
+    },
+    handler: writeFile,
+  },
   tree: {
     metadata: {
       name: "tree",
@@ -105,6 +115,10 @@ export function createAgentToolkit(context: ToolContext) {
     exec_command: createSecureTool(
       ToolCatalog.exec_command.metadata,
       ToolCatalog.exec_command.handler,
+    ).bind(null, context),
+    write_file: createSecureTool(
+      ToolCatalog.write_file.metadata,
+      ToolCatalog.write_file.handler,
     ).bind(null, context),
     tree: createSecureTool(
       ToolCatalog.tree.metadata,

--- a/src/registory/definitions.ts
+++ b/src/registory/definitions.ts
@@ -37,6 +37,28 @@ export const TOOL_DEFINITIONS = {
       },
     },
   },
+  write_file: {
+    type: "function",
+    function: {
+      name: "write_file",
+      description:
+        "Writes UTF-8 text to a file in the workspace. Use this for full content writes or creating new files.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Workspace-root-relative file path to write.",
+          },
+          content: {
+            type: "string",
+            description: "Full UTF-8 file content to write.",
+          },
+        },
+        required: ["path", "content"],
+      },
+    },
+  },
   exec_command: {
     type: "function",
     function: {

--- a/src/toolkit/invoke/index.ts
+++ b/src/toolkit/invoke/index.ts
@@ -12,6 +12,10 @@ import type {
 } from "../../tools/edit/read_file/types";
 import type { TreeInput, TreeOutput } from "../../tools/edit/tree/types";
 import type {
+  WriteFileInput,
+  WriteFileOutput,
+} from "../../tools/edit/write_file/types";
+import type {
   ExecCommandOptions,
   ExecCommandOutput,
 } from "../../tools/exec/exec_command/types";
@@ -23,6 +27,7 @@ import { InvokeToolError } from "./error";
 
 export type ToolArgsByName = {
   apply_patch: ApplyPatchInput;
+  write_file: WriteFileInput;
   exec_command: {
     cwd: string;
     command: string[];
@@ -38,6 +43,7 @@ export type ToolArgsByName = {
 
 export type ToolResultByName = {
   apply_patch: ApplyPatchOutput;
+  write_file: WriteFileOutput;
   exec_command: ExecCommandOutput;
   tree: TreeOutput;
   read_file: ReadFileOutput;
@@ -79,7 +85,8 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
 };
 
 const TOOL_ARGUMENT_RESOLVERS: ToolArgumentResolver = {
-  apply_patch: (args) => [args.filePath, args.content],
+  apply_patch: (args) => [args.filePath, args.patch],
+  write_file: (args) => [args.path, args.content],
   exec_command: (args) => [
     args.cwd,
     args.command,

--- a/src/tools/edit/apply_patch/tool.ts
+++ b/src/tools/edit/apply_patch/tool.ts
@@ -14,7 +14,7 @@ type Dependencies =
   | {
       usecase: (input: {
         filePath: string;
-        content: string;
+        patch: string;
       }) => Promise<ApplyPatchOutput>;
       spawn?: never;
       hasher?: never;
@@ -28,14 +28,14 @@ type Dependencies =
 export type ApplyPatchHandler = (
   context: ToolContext,
   filePath: string,
-  content: string,
+  patch: string,
 ) => Promise<ApplyPatchOutput>;
 
 const toUsecase = (
   deps: Dependencies,
 ): ((input: {
   filePath: string;
-  content: string;
+  patch: string;
 }) => Promise<ApplyPatchOutput>) => {
   if ("usecase" in deps && deps.usecase) {
     return deps.usecase;
@@ -57,10 +57,10 @@ export const createApplyPatch = (
   return async (
     _context: ToolContext,
     filePath: string,
-    content: string,
+    patch: string,
   ): Promise<ApplyPatchOutput> => {
     try {
-      const input = validateApplyPatchInput(filePath, content);
+      const input = validateApplyPatchInput(filePath, patch);
       return await usecase(input);
     } catch (error) {
       throw toInternalError(error);

--- a/src/tools/edit/apply_patch/types.ts
+++ b/src/tools/edit/apply_patch/types.ts
@@ -9,7 +9,7 @@ export type ApplyPatchErrorCode =
 
 export type ApplyPatchInput = {
   filePath: string;
-  content: string;
+  patch: string;
 };
 
 export type ApplyPatchOutput = {

--- a/src/tools/edit/apply_patch/usecase.ts
+++ b/src/tools/edit/apply_patch/usecase.ts
@@ -40,7 +40,7 @@ export const createApplyPatchUsecase = (
     const { exitCode, stderr } = await deps.spawn(
       ["git", "apply", "--whitespace=fix", "--include", input.filePath, "-"],
       {
-        stdin: Buffer.from(input.content),
+        stdin: Buffer.from(input.patch),
       },
     );
 

--- a/src/tools/edit/apply_patch/validator.ts
+++ b/src/tools/edit/apply_patch/validator.ts
@@ -3,7 +3,7 @@ import type { ApplyPatchInput } from "./types";
 
 export const validateApplyPatchInput = (
   filePath: string,
-  content: string,
+  patch: string,
 ): ApplyPatchInput => {
   if (typeof filePath !== "string" || filePath.trim().length === 0) {
     throw new ApplyPatchError(
@@ -12,12 +12,12 @@ export const validateApplyPatchInput = (
     );
   }
 
-  if (typeof content !== "string") {
-    throw new ApplyPatchError("INVALID_ARGUMENT", "content must be a string");
+  if (typeof patch !== "string") {
+    throw new ApplyPatchError("INVALID_ARGUMENT", "patch must be a string");
   }
 
   return {
     filePath,
-    content,
+    patch,
   };
 };

--- a/src/tools/edit/write_file/error.ts
+++ b/src/tools/edit/write_file/error.ts
@@ -1,0 +1,21 @@
+import type { WriteFileErrorCode } from "./types";
+
+export class WriteFileError extends Error {
+  readonly code: WriteFileErrorCode;
+
+  constructor(code: WriteFileErrorCode, message: string) {
+    super(`${code}: ${message}`);
+    this.code = code;
+    this.name = "WriteFileError";
+  }
+}
+
+export const toInternalError = (error: unknown): WriteFileError => {
+  if (error instanceof WriteFileError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new WriteFileError("INTERNAL", error.message);
+  }
+  return new WriteFileError("INTERNAL", String(error));
+};

--- a/src/tools/edit/write_file/tool.ts
+++ b/src/tools/edit/write_file/tool.ts
@@ -1,0 +1,36 @@
+import type { ToolContext } from "../../../factory";
+import { toInternalError } from "./error";
+import type { WriteFileOutput } from "./types";
+import { writeFileUsecase } from "./usecase";
+import { validateWriteFileInput } from "./validator";
+
+type Dependencies = {
+  usecase: typeof writeFileUsecase;
+};
+
+export type WriteFileHandler = (
+  context: ToolContext,
+  path: string,
+  content: string,
+) => Promise<WriteFileOutput>;
+
+export const createWriteFile = (
+  deps: Dependencies = {
+    usecase: writeFileUsecase,
+  },
+): WriteFileHandler => {
+  return async (
+    context: ToolContext,
+    path: string,
+    content: string,
+  ): Promise<WriteFileOutput> => {
+    try {
+      const input = validateWriteFileInput(path, content);
+      return await deps.usecase(context.workspaceRoot, input);
+    } catch (error) {
+      throw toInternalError(error);
+    }
+  };
+};
+
+export const writeFile = createWriteFile();

--- a/src/tools/edit/write_file/types.ts
+++ b/src/tools/edit/write_file/types.ts
@@ -1,0 +1,12 @@
+export type WriteFileErrorCode = "INVALID_ARGUMENT" | "NOT_FILE" | "INTERNAL";
+
+export type WriteFileInput = {
+  path: string;
+  content: string;
+};
+
+export type WriteFileOutput = {
+  path: string;
+  created: boolean;
+  bytes_written: number;
+};

--- a/src/tools/edit/write_file/usecase.ts
+++ b/src/tools/edit/write_file/usecase.ts
@@ -1,0 +1,61 @@
+import { mkdir, lstat } from "node:fs/promises";
+import { dirname, relative } from "node:path";
+import { WriteFileError } from "./error";
+import type { WriteFileInput, WriteFileOutput } from "./types";
+
+const toWorkspaceRelativePath = (
+  workspaceRoot: string,
+  absolutePath: string,
+): string => {
+  const relativePath = relative(workspaceRoot, absolutePath).replace(
+    /\\/g,
+    "/",
+  );
+  return relativePath.length === 0 ? "." : relativePath;
+};
+
+const isExistingDirectory = async (path: string): Promise<boolean> => {
+  try {
+    const stats = await lstat(path);
+    return stats.isDirectory();
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    if (e.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+};
+
+const isExistingFile = async (path: string): Promise<boolean> => {
+  try {
+    const stats = await lstat(path);
+    return stats.isFile();
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    if (e.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+};
+
+export const writeFileUsecase = async (
+  workspaceRoot: string,
+  input: WriteFileInput,
+): Promise<WriteFileOutput> => {
+  if (await isExistingDirectory(input.path)) {
+    throw new WriteFileError("NOT_FILE", `path is a directory: ${input.path}`);
+  }
+
+  const existed = await isExistingFile(input.path);
+
+  await mkdir(dirname(input.path), { recursive: true });
+  const bytesWritten = await Bun.write(input.path, input.content);
+
+  return {
+    path: toWorkspaceRelativePath(workspaceRoot, input.path),
+    created: !existed,
+    bytes_written: bytesWritten,
+  };
+};

--- a/src/tools/edit/write_file/validator.ts
+++ b/src/tools/edit/write_file/validator.ts
@@ -1,0 +1,23 @@
+import { WriteFileError } from "./error";
+import type { WriteFileInput } from "./types";
+
+export const validateWriteFileInput = (
+  path: string,
+  content: string,
+): WriteFileInput => {
+  if (typeof path !== "string" || path.trim().length === 0) {
+    throw new WriteFileError(
+      "INVALID_ARGUMENT",
+      "path must be a non-empty string",
+    );
+  }
+
+  if (typeof content !== "string") {
+    throw new WriteFileError("INVALID_ARGUMENT", "content must be a string");
+  }
+
+  return {
+    path,
+    content,
+  };
+};

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -207,6 +207,37 @@ describe("Library Integration (Toolkit & Guardrails)", () => {
     expect(result.data.branch).toBe("main");
   });
 
+  it("正常系: write_file が ToolCatalog と toolkit に登録され実行できること", async () => {
+    const mockHandler = vi.fn().mockResolvedValue({
+      path: "src/new.ts",
+      created: true,
+      bytes_written: 12,
+    });
+    (ToolCatalog.write_file as any).handler = mockHandler;
+
+    const context: ToolContext = {
+      workspaceRoot,
+      writeScope: "workspace-write",
+      policy: { tools: { write_file: "allow" }, defaultPolicy: "deny" },
+      env: { platform: "linux", osRelease: "5.4.0" },
+    };
+
+    const toolkit = createAgentToolkit(context);
+    const result = await toolkit.tools.write_file("src/new.ts", "const x = 1;");
+
+    expect(result.status).toBe("success");
+    if (result.status !== "success") {
+      throw new Error("Expected success but got non-success");
+    }
+
+    expect(mockHandler).toHaveBeenCalledWith(
+      context,
+      resolve(workspaceRoot, "src/new.ts"),
+      "const x = 1;",
+    );
+    expect(result.data.path).toBe("src/new.ts");
+  });
+
   it("正常系: invoke で read_file を実行し role/name/content を返すこと", async () => {
     const mockHandler = vi.fn().mockResolvedValue({
       path: "src/main.ts",
@@ -280,6 +311,7 @@ describe("Library Integration (Toolkit & Guardrails)", () => {
 
     expect(names).not.toContain("exec_command");
     expect(names).toContain("apply_patch");
+    expect(names).toContain("write_file");
     expect(names).toContain("tree");
   });
 });

--- a/test/registory/invoke.test.ts
+++ b/test/registory/invoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { resolve } from "node:path";
 import { createInvoke } from "../../src/toolkit/invoke/index";
 import { InvokeToolError } from "../../src/toolkit/invoke/error";
@@ -56,6 +56,40 @@ describe("createInvoke", () => {
       const invokeError = error as InvokeToolError;
       expect(invokeError.code).toBe("INVALID_TOOL_ARGUMENTS_TYPE");
       expect(invokeError.tool_name).toBe("read_file");
+    }
+  });
+
+  it("apply_patch は arguments.patch をハンドラーに渡すこと", async () => {
+    const context: ToolContext = {
+      workspaceRoot,
+      writeScope: "workspace-write",
+      policy: { tools: { apply_patch: "allow" }, defaultPolicy: "deny" },
+      env: { platform: "linux", osRelease: "5.4.0" },
+    };
+
+    const originalHandler = ToolCatalog.apply_patch.handler;
+    const mockHandler = vi.fn().mockResolvedValue({
+      file_path: resolve(workspaceRoot, "src/lib.ts"),
+      exit_code: 0,
+      changed: false,
+      stderr: "",
+    });
+    (ToolCatalog.apply_patch as any).handler = mockHandler;
+
+    try {
+      const invoke = createInvoke({ context, catalog: ToolCatalog });
+      await invoke("apply_patch", {
+        filePath: "src/lib.ts",
+        patch: "@@ -1 +1 @@\n-old\n+new\n",
+      });
+
+      expect(mockHandler).toHaveBeenCalledWith(
+        context,
+        resolve(workspaceRoot, "src/lib.ts"),
+        "@@ -1 +1 @@\n-old\n+new\n",
+      );
+    } finally {
+      (ToolCatalog.apply_patch as any).handler = originalHandler;
     }
   });
 });

--- a/test/registory/select.test.ts
+++ b/test/registory/select.test.ts
@@ -27,6 +27,7 @@ describe("selectAllowedTools", () => {
 
     expect(names).not.toContain("exec_command");
     expect(names).toContain("apply_patch");
+    expect(names).toContain("write_file");
     expect(names).toContain("git_status_summary");
   });
 

--- a/test/tool_context_policy_type.test.ts
+++ b/test/tool_context_policy_type.test.ts
@@ -9,6 +9,7 @@ function typeAssertions(): void {
       tools: {
         read_file: "allow",
         exec_command: "deny",
+        write_file: "allow",
       },
       defaultPolicy: "deny",
     },

--- a/test/tools/edit/write_file/tool.test.ts
+++ b/test/tools/edit/write_file/tool.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createSecureTool, type ToolContext } from "../../../../src/factory";
+import { writeFile as writeFileTool } from "../../../../src/tools/edit/write_file/tool";
+
+const createTempDir = async (): Promise<string> => {
+  return await mkdtemp(join(tmpdir(), "write-file-tool-"));
+};
+
+const createContext = (workspaceRoot: string): ToolContext => {
+  return {
+    workspaceRoot,
+    writeScope: "workspace-write",
+    policy: { tools: { write_file: "allow" }, defaultPolicy: "deny" },
+    env: {
+      platform: process.platform,
+      osRelease: "test",
+    },
+  };
+};
+
+const createSecureWriteFile = () => {
+  return createSecureTool(
+    { name: "write_file", isWriteOp: true },
+    writeFileTool,
+  );
+};
+
+describe("write_file tool", () => {
+  it("新規ファイルを書き込めること", async () => {
+    const workspaceRoot = await createTempDir();
+
+    try {
+      const result = await createSecureWriteFile()(
+        createContext(workspaceRoot),
+        "test/new-file.txt",
+        "hello",
+      );
+
+      expect(result.status).toBe("success");
+      if (result.status !== "success") {
+        throw new Error("Expected success but got non-success");
+      }
+
+      expect(result.data.path).toBe("test/new-file.txt");
+      expect(result.data.created).toBe(true);
+      expect(result.data.bytes_written).toBe(5);
+      expect(
+        await Bun.file(join(workspaceRoot, "test/new-file.txt")).text(),
+      ).toBe("hello");
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("既存ファイルを上書きできること", async () => {
+    const workspaceRoot = await createTempDir();
+
+    try {
+      await mkdir(join(workspaceRoot, "test"), { recursive: true });
+      await writeFile(join(workspaceRoot, "test", "existing.txt"), "before");
+
+      const result = await createSecureWriteFile()(
+        createContext(workspaceRoot),
+        "test/existing.txt",
+        "after",
+      );
+
+      expect(result.status).toBe("success");
+      if (result.status !== "success") {
+        throw new Error("Expected success but got non-success");
+      }
+
+      expect(result.data.path).toBe("test/existing.txt");
+      expect(result.data.created).toBe(false);
+      expect(
+        await Bun.file(join(workspaceRoot, "test/existing.txt")).text(),
+      ).toBe("after");
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("path がディレクトリの場合に NOT_FILE を返すこと", async () => {
+    const workspaceRoot = await createTempDir();
+
+    try {
+      await mkdir(join(workspaceRoot, "test"), { recursive: true });
+
+      const result = await createSecureWriteFile()(
+        createContext(workspaceRoot),
+        "test",
+        "x",
+      );
+
+      expect(result.status).toBe("failure");
+      if (result.status !== "failure") {
+        throw new Error("Expected failure but got success");
+      }
+      expect(result.message).toContain("NOT_FILE");
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("path が空文字の場合にワークスペースルートへの書き込みとして NOT_FILE を返すこと", async () => {
+    const workspaceRoot = await createTempDir();
+
+    try {
+      const result = await createSecureWriteFile()(
+        createContext(workspaceRoot),
+        "",
+        "x",
+      );
+
+      expect(result.status).toBe("failure");
+      if (result.status !== "failure") {
+        throw new Error("Expected failure but got success");
+      }
+      expect(result.message).toContain("NOT_FILE");
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 概要
- `apply_patch` の引数契約を `patch` に統一（schema / invoke / runtime）
- `write_file(path, content)` ツールを追加
- 既存テスト更新と新規テスト追加で回帰を防止

## 変更内容
- `invoke` で `apply_patch` の引数を `args.patch` から解決するよう修正
- `apply_patch` 実装内部の入力名を `content` から `patch` に統一
- `write_file` を `TOOL_DEFINITIONS` / `ToolCatalog` / `invoke` 型マップへ追加
- `write_file` の実装を追加（validator / usecase / tool / error / types）
- `write_file` の専用テスト追加

## テスト
- `bun run typecheck` ✅
- `bun test` ✅ (81 pass)
- `bun run format` ❌
  - 実行環境で `@biomejs/cli-darwin-arm64/biome` が見つからず失敗
